### PR TITLE
Additional Scripts

### DIFF
--- a/archive/DS3_v1.2.4_2020.CT
+++ b/archive/DS3_v1.2.4_2020.CT
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<CheatTable CheatEngineTableVersion="26">
+<CheatTable CheatEngineTableVersion="29">
   <Forms>
     <UDF1 Class="TCEForm" Encoding="Ascii85">y[wH$,cp?$B^^MDCy84pZI)j.0Xeh-Hn,hrU_4(Jl@6,^ELrTdKyI_f,JtFQpqM4?w)EdB!gk)u$34UL2D_Q2MvAgzDWdGDSuc)*TA#k)=.{5n(eI*D;z#LAm[7TjL,E7X?{RS}asuD6)$7Zu2%[PLm447mJ;r!P[0[k=VWZM-x?iNCA;x+w9Wywwjt^I8/TGmsT{S}V*ap.I$(j^=]?VIK!4%Rp8zbnlC{LfHo(_hl6W3:HAeZ@AQ^,b9,e!]0PN/v^ABhyqhDQ#dKW4/Uc_b[D3THV1eTXZ#k9(k+zieMqpHQ/tphv*U(IykeKpM4;)P#*nqb3QBClO$oi2$F}(jIDpZGs7^Xz=Z1[$5vOzbXRQf4uJwMuc^e14Zx[Pn{VM%[xt{*EC4XvkH9LCXA8Eqj.DnbNBRSay(X*a.qWtvLU{^wh470=RsE/,,j-!iO6e^8JCj2(NF*rr)zB$.S,_62{pz{D#6W]?Z_ytV;q;t.8RMd@6a]E#OnIbYbs]7K0-kOrQfw_16IBP),{8][z!q$7r-4t:Pd+tU#uz%v8Q4V.]56d[+-G%D(IhZ26*zu/jd@@HedixeWtW/M@]Z!cfu5P?;0*s?=ycd7_cMGI%:X]BLuOtxG?()eA3a/=R[[dd-@a57l21;6/:npBx^I%1TlmQX8fFiVpX0CP[+s6%r/bDU+3)0z+^*uMSb=@giw]%w5ehm)ou?e@/TAY8N2y1%0M70C2Rx_D7o=51hd=@9:Iz05D:VR6#h;I^9!**Itb97[XS*2O?N;6,vGdw0,+;Qq,{IykqT1O$YVX+NO#fgK!83UgrrI+;paVE2*]k}A*)VHdPMOi?E[aYs{QuE,XmNMVhzIVm5?!I,?%j]Z_Xs)gD?AaB2D?zR^3O%^K89gmW{:?tH#gbS/eKI@*3MVIt4HGN^0=(n}:XO37[Gqn1PHy]5Lz4)F-9WinMxm!+@=2;ETowa.f_gHIMB./5%HM?E@@T:lk[lFy/p:Fcv46U;ro#vNW%5CJ$c7]c!)Le/qF[TBQqdmjTKQt.+k=KzGP%rfFJD%sal+Y=IqH%;VYuZSLknGJeoxk^UkH.wSOAJdjAj9uXh90z{T*#%$yLmloK+3T@,S:i9D.v5cOny@+on8]-7UN+/L#jYdtR7_sJNE_.EadNGcAPdHb+eDP^=5Bkiti5F}(jt]FDZBm_G?TI-+M,;79xeKkuwz6?z.!Y?uEO8{OGuR26fzu-+DgKI*+C(8FdHpa{RlFa?F[!6vSBZsO]h2D+d!?!jHkE5}W{qnybVuZ7as59w]hE03l^vnHy2l:P0fBSo.%PNDZz#:Ix%u]r()OWI7V.aSdQmkda3X$A8(DL=^nVP.3DA49N%OsWO.z?/8R==.u$tM66dfj7at^TKC2[209O%/nNJ(k800,vAcUn:wjdy0)DgC0U6fF;.Am$*+#4Gc{O]d@RW@,_qj,w^24]v:lGVkgN/^y]3ZuZD/h?s]gC@7V@Y%QmJLZ*YB^[OtW=$vjmCc@Q_b]h/aZv#0]X6:IN:_%IgZr_%C$c28Z%YqGzUf%A4iI:o+F=h=gxC[.}0{hVcfcoZ!=}Ag(fs}.Ez.U6//^RXrK86*#r%L:NWRq)+:TSNFaBvTgZmDtv_I095hf]IrcX-HFIJTC!x!2=e?dbXP+Zu[</UDF1>
     <BACForm Class="TCEForm" Encoding="Ascii85">jgrld):ZT#o(Tii^s/u/5QlJp/p3,R.:pyAZqyY*RB9x,rW=1ll+W/ch2^mg?DfOzcpt:;N5OWSG%bzN*7bLNmzi)!,XNt+25,p$zX;o_Tcc}AM=HiKs^I)66Nr^8s^I67gmdkWVthggU1?)6%a3!4aArOml?xl^gv6!i/LnD06cTS/dT2?TI=l-b(]%M{XoGUAdrh+ZxIi3bo#+(Nj56MU(k]U3ysw*CQELJ;Jc[;57qTt(5$^U1WK+vcJBsHYNdk!q;:^gFG$vF94m+Z0Thf(Z0I)S^jOQ?58B-i8s8K]D1k_md;ceJGjpe*3n6S:#oMK]F.4s$co;H8huty*}Wp%6c^ZeY:V{Udz?}T1Vyky)7)k7k?qVU./e)r$2Z:jZ{,H%eI*MI$pJ?xDVr*K$kQ#VUtPn{D7d0.7e:TcfC8MII2MW0AxN2DP3io7@Nq{38R.QxKmtumCnrwz^#6(+4i?z_,zazLkZgw8X8=GqaG2[3YV4/xf!X;f#6x2-ftaZJ0Frjqw$t5j5UDHV@MN;;Mzs;di5+gmC.KBd{?QpxO9x.R3q-BM},6YL2PI/?aW!k#xUnZ75}Wi%hJ:XiuSr(UIMt-#YAv*Z;BoD6O$T-P6U[}kZB.6[zX[[=@8QG(8%p[n?Vr%dz8tKwT3--!r{87*)2o!%8:g7Y!^nuVxnO,3@ixS?3!,txn</BACForm>
@@ -16654,6 +16654,49 @@ end
 
 [DISABLE]
 reviveTimer.destroy()
+</AssemblerScript>
+            </CheatEntry>
+            <CheatEntry>
+              <ID>1337103735</ID>
+              <Description>"No Bloodstain / Souls Lost on Death"</Description>
+              <Options moHideChildren="1"/>
+              <LastState/>
+              <VariableType>Auto Assembler Script</VariableType>
+              <AssemblerScript>{ no bloodstain and no souls lost on death ~saucy }
+[ENABLE]
+DarkSoulsIII.exe+49EABF:
+db 90 90 90 90 90
+[DISABLE]
+DarkSoulsIII.exe+49EABF:
+call DarkSoulsIII.exe+4862F0
+</AssemblerScript>
+              <CheatEntries>
+                <CheatEntry>
+                  <ID>1337103609</ID>
+                  <Description>"CollisionValue"</Description>
+                  <DropDownList ReadOnly="1" DisplayValueAsItem="1">0:Disabled
+1:Enabled
+</DropDownList>
+                  <VariableType>Byte</VariableType>
+                  <Address>CollisionValue</Address>
+                </CheatEntry>
+              </CheatEntries>
+            </CheatEntry>
+            <CheatEntry>
+              <ID>1337103736</ID>
+              <Description>"Prevent Player Angle from Changing (Pivots)"</Description>
+              <LastState/>
+              <VariableType>Auto Assembler Script</VariableType>
+              <AssemblerScript>{ prevents the change of player angle from bonfires and pivots. ~saucy }
+[ENABLE]
+DarkSoulsIII.exe+9D5B91:
+db 90 90 90 90
+[DISABLE]
+DarkSoulsIII.exe+9D5B91:
+movaps [rbx+70],xmm4
+
+
+
 </AssemblerScript>
             </CheatEntry>
             <CheatEntry>
@@ -98058,9 +98101,7 @@ unregistersymbol(TakenDamage)
   <CheatCodes>
     <CodeEntry>
       <Description>Change of movaps [rcx+rdx*8+20],xmm0</Description>
-      <Address>1408F2A50</Address>
-      <ModuleName>DarkSoulsIII.exe</ModuleName>
-      <ModuleNameOffset>8F2A50</ModuleNameOffset>
+      <AddressString>DarkSoulsIII.exe+8F2A50</AddressString>
       <Before>
         <Byte>0F</Byte>
         <Byte>29</Byte>
@@ -98085,9 +98126,7 @@ unregistersymbol(TakenDamage)
     </CodeEntry>
     <CodeEntry>
       <Description>Change of movdqa [rcx+70],xmm4</Description>
-      <Address>1409D119A</Address>
-      <ModuleName>DarkSoulsIII.exe</ModuleName>
-      <ModuleNameOffset>9D119A</ModuleNameOffset>
+      <AddressString>DarkSoulsIII.exe+9D119A</AddressString>
       <Before>
         <Byte>00</Byte>
         <Byte>00</Byte>

--- a/archive/DS3_v1.2.4_2020.CT
+++ b/archive/DS3_v1.2.4_2020.CT
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<CheatTable CheatEngineTableVersion="29">
+<CheatTable CheatEngineTableVersion="26">
   <Forms>
     <UDF1 Class="TCEForm" Encoding="Ascii85">y[wH$,cp?$B^^MDCy84pZI)j.0Xeh-Hn,hrU_4(Jl@6,^ELrTdKyI_f,JtFQpqM4?w)EdB!gk)u$34UL2D_Q2MvAgzDWdGDSuc)*TA#k)=.{5n(eI*D;z#LAm[7TjL,E7X?{RS}asuD6)$7Zu2%[PLm447mJ;r!P[0[k=VWZM-x?iNCA;x+w9Wywwjt^I8/TGmsT{S}V*ap.I$(j^=]?VIK!4%Rp8zbnlC{LfHo(_hl6W3:HAeZ@AQ^,b9,e!]0PN/v^ABhyqhDQ#dKW4/Uc_b[D3THV1eTXZ#k9(k+zieMqpHQ/tphv*U(IykeKpM4;)P#*nqb3QBClO$oi2$F}(jIDpZGs7^Xz=Z1[$5vOzbXRQf4uJwMuc^e14Zx[Pn{VM%[xt{*EC4XvkH9LCXA8Eqj.DnbNBRSay(X*a.qWtvLU{^wh470=RsE/,,j-!iO6e^8JCj2(NF*rr)zB$.S,_62{pz{D#6W]?Z_ytV;q;t.8RMd@6a]E#OnIbYbs]7K0-kOrQfw_16IBP),{8][z!q$7r-4t:Pd+tU#uz%v8Q4V.]56d[+-G%D(IhZ26*zu/jd@@HedixeWtW/M@]Z!cfu5P?;0*s?=ycd7_cMGI%:X]BLuOtxG?()eA3a/=R[[dd-@a57l21;6/:npBx^I%1TlmQX8fFiVpX0CP[+s6%r/bDU+3)0z+^*uMSb=@giw]%w5ehm)ou?e@/TAY8N2y1%0M70C2Rx_D7o=51hd=@9:Iz05D:VR6#h;I^9!**Itb97[XS*2O?N;6,vGdw0,+;Qq,{IykqT1O$YVX+NO#fgK!83UgrrI+;paVE2*]k}A*)VHdPMOi?E[aYs{QuE,XmNMVhzIVm5?!I,?%j]Z_Xs)gD?AaB2D?zR^3O%^K89gmW{:?tH#gbS/eKI@*3MVIt4HGN^0=(n}:XO37[Gqn1PHy]5Lz4)F-9WinMxm!+@=2;ETowa.f_gHIMB./5%HM?E@@T:lk[lFy/p:Fcv46U;ro#vNW%5CJ$c7]c!)Le/qF[TBQqdmjTKQt.+k=KzGP%rfFJD%sal+Y=IqH%;VYuZSLknGJeoxk^UkH.wSOAJdjAj9uXh90z{T*#%$yLmloK+3T@,S:i9D.v5cOny@+on8]-7UN+/L#jYdtR7_sJNE_.EadNGcAPdHb+eDP^=5Bkiti5F}(jt]FDZBm_G?TI-+M,;79xeKkuwz6?z.!Y?uEO8{OGuR26fzu-+DgKI*+C(8FdHpa{RlFa?F[!6vSBZsO]h2D+d!?!jHkE5}W{qnybVuZ7as59w]hE03l^vnHy2l:P0fBSo.%PNDZz#:Ix%u]r()OWI7V.aSdQmkda3X$A8(DL=^nVP.3DA49N%OsWO.z?/8R==.u$tM66dfj7at^TKC2[209O%/nNJ(k800,vAcUn:wjdy0)DgC0U6fF;.Am$*+#4Gc{O]d@RW@,_qj,w^24]v:lGVkgN/^y]3ZuZD/h?s]gC@7V@Y%QmJLZ*YB^[OtW=$vjmCc@Q_b]h/aZv#0]X6:IN:_%IgZr_%C$c28Z%YqGzUf%A4iI:o+F=h=gxC[.}0{hVcfcoZ!=}Ag(fs}.Ez.U6//^RXrK86*#r%L:NWRq)+:TSNFaBvTgZmDtv_I095hf]IrcX-HFIJTC!x!2=e?dbXP+Zu[</UDF1>
     <BACForm Class="TCEForm" Encoding="Ascii85">jgrld):ZT#o(Tii^s/u/5QlJp/p3,R.:pyAZqyY*RB9x,rW=1ll+W/ch2^mg?DfOzcpt:;N5OWSG%bzN*7bLNmzi)!,XNt+25,p$zX;o_Tcc}AM=HiKs^I)66Nr^8s^I67gmdkWVthggU1?)6%a3!4aArOml?xl^gv6!i/LnD06cTS/dT2?TI=l-b(]%M{XoGUAdrh+ZxIi3bo#+(Nj56MU(k]U3ysw*CQELJ;Jc[;57qTt(5$^U1WK+vcJBsHYNdk!q;:^gFG$vF94m+Z0Thf(Z0I)S^jOQ?58B-i8s8K]D1k_md;ceJGjpe*3n6S:#oMK]F.4s$co;H8huty*}Wp%6c^ZeY:V{Udz?}T1Vyky)7)k7k?qVU./e)r$2Z:jZ{,H%eI*MI$pJ?xDVr*K$kQ#VUtPn{D7d0.7e:TcfC8MII2MW0AxN2DP3io7@Nq{38R.QxKmtumCnrwz^#6(+4i?z_,zazLkZgw8X8=GqaG2[3YV4/xf!X;f#6x2-ftaZJ0Frjqw$t5j5UDHV@MN;;Mzs;di5+gmC.KBd{?QpxO9x.R3q-BM},6YL2PI/?aW!k#xUnZ75}Wi%hJ:XiuSr(UIMt-#YAv*Z;BoD6O$T-P6U[}kZB.6[zX[[=@8QG(8%p[n?Vr%dz8tKwT3--!r{87*)2o!%8:g7Y!^nuVxnO,3@ixS?3!,txn</BACForm>
@@ -16730,49 +16730,6 @@ if(syntaxcheck) then return end
 if(PlayerCheckTimer ~= nil) then
   PlayerCheckTimer.setEnabled(false)
 end
-</AssemblerScript>
-            </CheatEntry>
-            <CheatEntry>
-              <ID>1337103608</ID>
-              <Description>"No Bloodstain / Souls Lost on Death"</Description>
-              <Options moHideChildren="1"/>
-              <LastState/>
-              <VariableType>Auto Assembler Script</VariableType>
-              <AssemblerScript>{ no bloodstain and no souls lost on death ~saucy }
-[ENABLE]
-DarkSoulsIII.exe+49EABF:
-db 90 90 90 90 90
-[DISABLE]
-DarkSoulsIII.exe+49EABF:
-call DarkSoulsIII.exe+4862F0
-</AssemblerScript>
-              <CheatEntries>
-                <CheatEntry>
-                  <ID>1337103609</ID>
-                  <Description>"CollisionValue"</Description>
-                  <DropDownList ReadOnly="1" DisplayValueAsItem="1">0:Disabled
-1:Enabled
-</DropDownList>
-                  <VariableType>Byte</VariableType>
-                  <Address>CollisionValue</Address>
-                </CheatEntry>
-              </CheatEntries>
-            </CheatEntry>
-            <CheatEntry>
-              <ID>1337103607</ID>
-              <Description>"Prevent Player Angle from Changing (Pivots)"</Description>
-              <LastState/>
-              <VariableType>Auto Assembler Script</VariableType>
-              <AssemblerScript>{ prevents the change of player angle from bonfires and pivots. ~saucy }
-[ENABLE]
-DarkSoulsIII.exe+9D5B91:
-db 90 90 90 90
-[DISABLE]
-DarkSoulsIII.exe+9D5B91:
-movaps [rbx+70],xmm4
-
-
-
 </AssemblerScript>
             </CheatEntry>
             <CheatEntry>
@@ -98101,7 +98058,9 @@ unregistersymbol(TakenDamage)
   <CheatCodes>
     <CodeEntry>
       <Description>Change of movaps [rcx+rdx*8+20],xmm0</Description>
-      <AddressString>DarkSoulsIII.exe+8F2A50</AddressString>
+      <Address>1408F2A50</Address>
+      <ModuleName>DarkSoulsIII.exe</ModuleName>
+      <ModuleNameOffset>8F2A50</ModuleNameOffset>
       <Before>
         <Byte>0F</Byte>
         <Byte>29</Byte>
@@ -98126,7 +98085,9 @@ unregistersymbol(TakenDamage)
     </CodeEntry>
     <CodeEntry>
       <Description>Change of movdqa [rcx+70],xmm4</Description>
-      <AddressString>DarkSoulsIII.exe+9D119A</AddressString>
+      <Address>1409D119A</Address>
+      <ModuleName>DarkSoulsIII.exe</ModuleName>
+      <ModuleNameOffset>9D119A</ModuleNameOffset>
       <Before>
         <Byte>00</Byte>
         <Byte>00</Byte>

--- a/archive/DS3_v1.2.4_2020.CT
+++ b/archive/DS3_v1.2.4_2020.CT
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<CheatTable CheatEngineTableVersion="26">
+<CheatTable CheatEngineTableVersion="29">
   <Forms>
     <UDF1 Class="TCEForm" Encoding="Ascii85">y[wH$,cp?$B^^MDCy84pZI)j.0Xeh-Hn,hrU_4(Jl@6,^ELrTdKyI_f,JtFQpqM4?w)EdB!gk)u$34UL2D_Q2MvAgzDWdGDSuc)*TA#k)=.{5n(eI*D;z#LAm[7TjL,E7X?{RS}asuD6)$7Zu2%[PLm447mJ;r!P[0[k=VWZM-x?iNCA;x+w9Wywwjt^I8/TGmsT{S}V*ap.I$(j^=]?VIK!4%Rp8zbnlC{LfHo(_hl6W3:HAeZ@AQ^,b9,e!]0PN/v^ABhyqhDQ#dKW4/Uc_b[D3THV1eTXZ#k9(k+zieMqpHQ/tphv*U(IykeKpM4;)P#*nqb3QBClO$oi2$F}(jIDpZGs7^Xz=Z1[$5vOzbXRQf4uJwMuc^e14Zx[Pn{VM%[xt{*EC4XvkH9LCXA8Eqj.DnbNBRSay(X*a.qWtvLU{^wh470=RsE/,,j-!iO6e^8JCj2(NF*rr)zB$.S,_62{pz{D#6W]?Z_ytV;q;t.8RMd@6a]E#OnIbYbs]7K0-kOrQfw_16IBP),{8][z!q$7r-4t:Pd+tU#uz%v8Q4V.]56d[+-G%D(IhZ26*zu/jd@@HedixeWtW/M@]Z!cfu5P?;0*s?=ycd7_cMGI%:X]BLuOtxG?()eA3a/=R[[dd-@a57l21;6/:npBx^I%1TlmQX8fFiVpX0CP[+s6%r/bDU+3)0z+^*uMSb=@giw]%w5ehm)ou?e@/TAY8N2y1%0M70C2Rx_D7o=51hd=@9:Iz05D:VR6#h;I^9!**Itb97[XS*2O?N;6,vGdw0,+;Qq,{IykqT1O$YVX+NO#fgK!83UgrrI+;paVE2*]k}A*)VHdPMOi?E[aYs{QuE,XmNMVhzIVm5?!I,?%j]Z_Xs)gD?AaB2D?zR^3O%^K89gmW{:?tH#gbS/eKI@*3MVIt4HGN^0=(n}:XO37[Gqn1PHy]5Lz4)F-9WinMxm!+@=2;ETowa.f_gHIMB./5%HM?E@@T:lk[lFy/p:Fcv46U;ro#vNW%5CJ$c7]c!)Le/qF[TBQqdmjTKQt.+k=KzGP%rfFJD%sal+Y=IqH%;VYuZSLknGJeoxk^UkH.wSOAJdjAj9uXh90z{T*#%$yLmloK+3T@,S:i9D.v5cOny@+on8]-7UN+/L#jYdtR7_sJNE_.EadNGcAPdHb+eDP^=5Bkiti5F}(jt]FDZBm_G?TI-+M,;79xeKkuwz6?z.!Y?uEO8{OGuR26fzu-+DgKI*+C(8FdHpa{RlFa?F[!6vSBZsO]h2D+d!?!jHkE5}W{qnybVuZ7as59w]hE03l^vnHy2l:P0fBSo.%PNDZz#:Ix%u]r()OWI7V.aSdQmkda3X$A8(DL=^nVP.3DA49N%OsWO.z?/8R==.u$tM66dfj7at^TKC2[209O%/nNJ(k800,vAcUn:wjdy0)DgC0U6fF;.Am$*+#4Gc{O]d@RW@,_qj,w^24]v:lGVkgN/^y]3ZuZD/h?s]gC@7V@Y%QmJLZ*YB^[OtW=$vjmCc@Q_b]h/aZv#0]X6:IN:_%IgZr_%C$c28Z%YqGzUf%A4iI:o+F=h=gxC[.}0{hVcfcoZ!=}Ag(fs}.Ez.U6//^RXrK86*#r%L:NWRq)+:TSNFaBvTgZmDtv_I095hf]IrcX-HFIJTC!x!2=e?dbXP+Zu[</UDF1>
     <BACForm Class="TCEForm" Encoding="Ascii85">jgrld):ZT#o(Tii^s/u/5QlJp/p3,R.:pyAZqyY*RB9x,rW=1ll+W/ch2^mg?DfOzcpt:;N5OWSG%bzN*7bLNmzi)!,XNt+25,p$zX;o_Tcc}AM=HiKs^I)66Nr^8s^I67gmdkWVthggU1?)6%a3!4aArOml?xl^gv6!i/LnD06cTS/dT2?TI=l-b(]%M{XoGUAdrh+ZxIi3bo#+(Nj56MU(k]U3ysw*CQELJ;Jc[;57qTt(5$^U1WK+vcJBsHYNdk!q;:^gFG$vF94m+Z0Thf(Z0I)S^jOQ?58B-i8s8K]D1k_md;ceJGjpe*3n6S:#oMK]F.4s$co;H8huty*}Wp%6c^ZeY:V{Udz?}T1Vyky)7)k7k?qVU./e)r$2Z:jZ{,H%eI*MI$pJ?xDVr*K$kQ#VUtPn{D7d0.7e:TcfC8MII2MW0AxN2DP3io7@Nq{38R.QxKmtumCnrwz^#6(+4i?z_,zazLkZgw8X8=GqaG2[3YV4/xf!X;f#6x2-ftaZJ0Frjqw$t5j5UDHV@MN;;Mzs;di5+gmC.KBd{?QpxO9x.R3q-BM},6YL2PI/?aW!k#xUnZ75}Wi%hJ:XiuSr(UIMt-#YAv*Z;BoD6O$T-P6U[}kZB.6[zX[[=@8QG(8%p[n?Vr%dz8tKwT3--!r{87*)2o!%8:g7Y!^nuVxnO,3@ixS?3!,txn</BACForm>
@@ -16730,6 +16730,49 @@ if(syntaxcheck) then return end
 if(PlayerCheckTimer ~= nil) then
   PlayerCheckTimer.setEnabled(false)
 end
+</AssemblerScript>
+            </CheatEntry>
+            <CheatEntry>
+              <ID>1337103608</ID>
+              <Description>"No Bloodstain / Souls Lost on Death"</Description>
+              <Options moHideChildren="1"/>
+              <LastState/>
+              <VariableType>Auto Assembler Script</VariableType>
+              <AssemblerScript>{ no bloodstain and no souls lost on death ~saucy }
+[ENABLE]
+DarkSoulsIII.exe+49EABF:
+db 90 90 90 90 90
+[DISABLE]
+DarkSoulsIII.exe+49EABF:
+call DarkSoulsIII.exe+4862F0
+</AssemblerScript>
+              <CheatEntries>
+                <CheatEntry>
+                  <ID>1337103609</ID>
+                  <Description>"CollisionValue"</Description>
+                  <DropDownList ReadOnly="1" DisplayValueAsItem="1">0:Disabled
+1:Enabled
+</DropDownList>
+                  <VariableType>Byte</VariableType>
+                  <Address>CollisionValue</Address>
+                </CheatEntry>
+              </CheatEntries>
+            </CheatEntry>
+            <CheatEntry>
+              <ID>1337103607</ID>
+              <Description>"Prevent Player Angle from Changing (Pivots)"</Description>
+              <LastState/>
+              <VariableType>Auto Assembler Script</VariableType>
+              <AssemblerScript>{ prevents the change of player angle from bonfires and pivots. ~saucy }
+[ENABLE]
+DarkSoulsIII.exe+9D5B91:
+db 90 90 90 90
+[DISABLE]
+DarkSoulsIII.exe+9D5B91:
+movaps [rbx+70],xmm4
+
+
+
 </AssemblerScript>
             </CheatEntry>
             <CheatEntry>
@@ -98058,9 +98101,7 @@ unregistersymbol(TakenDamage)
   <CheatCodes>
     <CodeEntry>
       <Description>Change of movaps [rcx+rdx*8+20],xmm0</Description>
-      <Address>1408F2A50</Address>
-      <ModuleName>DarkSoulsIII.exe</ModuleName>
-      <ModuleNameOffset>8F2A50</ModuleNameOffset>
+      <AddressString>DarkSoulsIII.exe+8F2A50</AddressString>
       <Before>
         <Byte>0F</Byte>
         <Byte>29</Byte>
@@ -98085,9 +98126,7 @@ unregistersymbol(TakenDamage)
     </CodeEntry>
     <CodeEntry>
       <Description>Change of movdqa [rcx+70],xmm4</Description>
-      <Address>1409D119A</Address>
-      <ModuleName>DarkSoulsIII.exe</ModuleName>
-      <ModuleNameOffset>9D119A</ModuleNameOffset>
+      <AddressString>DarkSoulsIII.exe+9D119A</AddressString>
       <Before>
         <Byte>00</Byte>
         <Byte>00</Byte>


### PR DESCRIPTION
I've added two entries under the Scripts header.
### No Bloodstain / Souls Lost on Death
This script may be useful for those playing offline that don't want the pressure of losing souls on death.
```
[ENABLE]
DarkSoulsIII.exe+49EABF:
db 90 90 90 90 90
[DISABLE]
DarkSoulsIII.exe+49EABF:
call DarkSoulsIII.exe+4862F0
```
_The call for bloodstain creation is replaced by a five-byte NOP, DarkSoulsIII.exe+4862F0 can be called to produce bloodstains without additional arguments._

 ### Prevent Player Angle from Changing (Pivots)
This script prevents the change of player angle from bonfires and other elements like pivots (animation will still occur). Mainly just for those that want something neat I guess, could be moved to the Movement and Animations header. 
```
[ENABLE]
DarkSoulsIII.exe+9D5B91:
db 90 90 90 90
[DISABLE]
DarkSoulsIII.exe+9D5B91:
movaps [rbx+70],xmm4

```
_a four-byte NOP, no need to allocate memory for this._


